### PR TITLE
Changes Composer package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Changed
+- Package name is now `rebelcode/eddbk`.
 
 ## [0.1-alpha13] - 2018-06-13
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "rebelcode/edd-bookings",
+    "name": "rebelcode/eddbk",
     "description": "The new EDD Bookings.",
     "type": "wordpress-plugin",
     "license": "GPL-3.0",


### PR DESCRIPTION
The previous package name is in use by the [previous version of EDD Bookings](http://github.com/RebelCode/edd-bookings). This changes the package name to `rebelcode/eddbk`.